### PR TITLE
Hotfix/load fail fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gadzby",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gadzby",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "@base-ui/react": "^1.0.0",
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gadzby",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/(dashboard)/shops/[slug]/_components/self-service-view.tsx
+++ b/src/app/(dashboard)/shops/[slug]/_components/self-service-view.tsx
@@ -74,6 +74,8 @@ export function SelfServiceView({
             if (res.famss && res.famss.length > 0) {
                 setUserFamss(res.famss);
             }
+        }).catch((err) => {
+            console.error("Failed to fetch famss:", err);
         });
     }, [famssEnabled]);
 
@@ -177,7 +179,11 @@ export function SelfServiceView({
 
                 if (disconnectAfterCheckout) {
                     setTimeout(async () => {
-                        await logoutAction();
+                        try {
+                            await logoutAction();
+                        } catch (err) {
+                            console.error("Logout failed:", err);
+                        }
                     }, 1000);
                 } else {
                     setTimeout(() => setSuccess(null), 3000);

--- a/src/app/(dashboard)/shops/[slug]/_components/shop-manager-view.tsx
+++ b/src/app/(dashboard)/shops/[slug]/_components/shop-manager-view.tsx
@@ -97,6 +97,8 @@ export function ShopManagerView({
 					if (res.famss) {
 						setClientFamss(res.famss);
 					}
+				}).catch((err) => {
+					console.error("Failed to fetch famss:", err);
 				});
 			}
 		}


### PR DESCRIPTION
Fix TypeError sur la page self-service et sell :

# TypeError: Load failed

**Issue ID:** 91609237
**Project:** gadzby
**Date:** 08/04/2026 09:00:44
## Issue Summary
TypeError during POST /shops/:slug/self-service fetch
**What's wrong:** A **TypeError** occurred during a **fetch** operation for **POST /shops/:slug/self-service**, failing to load server action data.
**In the trace:** The trace shows numerous **GET** requests for the root path and **POST** requests to `/shops/[slug]/self-service`, indicating **frequent navigation and interaction**.
**Possible cause:** The **fetch** call within `server-action-reducer.ts` may be **failing due to an invalid or malformed request body or headers**, possibly related to **crypto.getRandomValues**.

## Tags

- **browser:** Mobile Safari 26.2
- **browser.name:** Mobile Safari
- **device:** iPhone
- **device.family:** iPhone
- **environment:** production
- **handled:** no
- **level:** error
- **mechanism:** auto.browser.global_handlers.onunhandledrejection
- **os:** iOS 18.7
- **os.name:** iOS
- **replayId:** 1c7a47463e4a4c718bdef1a2c8ecdb9b
- **transaction:** /shops/:slug/self-service
- **turbopack:** True
- **url:** https://boquette.gadzby-app.com/shops/4h/self-service

## Exception

### Exception 1
**Type:** TypeError
**Value:** Load failed

#### Stacktrace

```
 fetchServerAction in node_modules/next/src/client/components/router-reducer/reducers/server-action-reducer.ts [Line 143] (Not in app)
    headers[NEXT_REQUEST_ID_HEADER] = crypto
      .getRandomValues(new Uint32Array(1))[0]
      .toString(16)
  }

  const res = await fetch(state.canonicalUrl, { method: 'POST', headers, body })  <-- SUSPECT LINE

  // Handle server actions that the server didn't recognize.
  const unrecognizedActionHeader = res.headers.get(NEXT_ACTION_NOT_FOUND_HEADER)
  if (unrecognizedActionHeader === '1') {
    throw new UnrecognizedActionError(
```


