### PR TITLE
fix: gérer les transactions TOPUP bloquées en attente

### DIFF
--- a/src/app/(dashboard)/topup/page.tsx
+++ b/src/app/(dashboard)/topup/page.tsx
@@ -1,8 +1,9 @@
-import { eq } from "drizzle-orm";
+import { and, eq, lt } from "drizzle-orm";
 import { redirect } from "next/navigation";
 
 import { db } from "@/db";
 import { paymentMethods } from "@/db/schema/payment-methods";
+import { transactions } from "@/db/schema/transactions";
 import { users } from "@/db/schema/users";
 import { verifySession } from "@/lib/session";
 
@@ -11,6 +12,22 @@ import { TopUpForm } from "./_components/topup-form";
 export default async function TopUpPage() {
 	const session = await verifySession();
 	if (!session) redirect("/login");
+
+	// Cancel any PENDING TOPUP transactions older than 30 minutes —
+	// these were abandoned when the user left the provider checkout page.
+	const thirtyMinutesAgo = new Date(Date.now() - 30 * 60 * 1000);
+	await db
+		.update(transactions)
+		.set({ status: "CANCELLED" })
+		.where(
+			and(
+				eq(transactions.issuerId, session.userId),
+				eq(transactions.type, "TOPUP"),
+				eq(transactions.status, "PENDING"),
+				lt(transactions.createdAt, thirtyMinutesAgo)
+			)
+		);
+
 	const user = await db.query.users.findFirst({
 		where: eq(users.id, session.userId),
 	});

--- a/src/app/api/webhooks/payment/__tests__/route.test.ts
+++ b/src/app/api/webhooks/payment/__tests__/route.test.ts
@@ -49,6 +49,31 @@ describe("POST /api/webhooks/payment", () => {
 		expect(db.transaction).not.toHaveBeenCalled();
 	});
 
+	it("marks transaction as FAILED and returns 200 when shouldFail is true", async () => {
+		vi.mocked(factory.getPaymentProvider).mockResolvedValue({
+			createPayment: vi.fn(),
+			verifyWebhook: vi.fn().mockResolvedValue({
+				isValid: true,
+				shouldFail: true,
+				transactionId: "tx-uuid-fail",
+			}),
+		});
+
+		vi.mocked(db.transaction).mockResolvedValue(undefined);
+
+		const req = new NextRequest(
+			"http://localhost/api/webhooks/payment?provider=helloasso",
+			{ method: "POST", body: "{}" }
+		);
+
+		const res = await POST(req);
+		const json = await res.json();
+
+		expect(res.status).toBe(200);
+		expect(json.received).toBe(true);
+		expect(db.transaction).toHaveBeenCalledOnce();
+	});
+
 	it("processes the transaction and returns 200 for a valid webhook", async () => {
 		vi.mocked(factory.getPaymentProvider).mockResolvedValue({
 			createPayment: vi.fn(),

--- a/src/app/api/webhooks/payment/route.ts
+++ b/src/app/api/webhooks/payment/route.ts
@@ -34,6 +34,26 @@ export async function POST(request: NextRequest) {
 
 		const txId = verification.transactionId;
 
+		if (verification.shouldFail) {
+			// Provider reported a declined or errored payment — mark as FAILED
+			await db.transaction(async (tx) => {
+				const [currentTx] = await tx
+					.select()
+					.from(transactions)
+					.where(eq(transactions.id, txId))
+					.for("update");
+
+				if (!currentTx || currentTx.status !== "PENDING") return;
+
+				await tx
+					.update(transactions)
+					.set({ status: "FAILED" })
+					.where(eq(transactions.id, txId));
+			});
+
+			return NextResponse.json({ received: true });
+		}
+
 		// TODO: Refactor to use transactions service
 		await db.transaction(async (tx) => {
 			// 1. Get current transaction status

--- a/src/lib/payments/adapters/__tests__/helloasso.test.ts
+++ b/src/lib/payments/adapters/__tests__/helloasso.test.ts
@@ -45,7 +45,7 @@ describe("HelloAssoAdapter", () => {
 			expect(result.providerTransactionId).toBe("42");
 		});
 
-		it("returns isValid false for a Refused Payment event", async () => {
+		it("returns shouldFail true for a Refused Payment event", async () => {
 			const req = makeWebhookRequest({
 				eventType: "Payment",
 				data: { state: "Refused", amount: 1000, id: 42 },
@@ -54,7 +54,23 @@ describe("HelloAssoAdapter", () => {
 
 			const result = await adapter.verifyWebhook(req);
 
-			expect(result.isValid).toBe(false);
+			expect(result.isValid).toBe(true);
+			expect(result.shouldFail).toBe(true);
+			expect(result.transactionId).toBe("tx-uuid-123");
+		});
+
+		it("returns shouldFail true for an Error Payment event", async () => {
+			const req = makeWebhookRequest({
+				eventType: "Payment",
+				data: { state: "Error", amount: 1000, id: 42 },
+				metadata: { internalTransactionId: "tx-uuid-123" },
+			});
+
+			const result = await adapter.verifyWebhook(req);
+
+			expect(result.isValid).toBe(true);
+			expect(result.shouldFail).toBe(true);
+			expect(result.transactionId).toBe("tx-uuid-123");
 		});
 
 		it("returns isValid false for an Order event (non-Payment type)", async () => {

--- a/src/lib/payments/adapters/helloasso.ts
+++ b/src/lib/payments/adapters/helloasso.ts
@@ -166,16 +166,23 @@ export class HelloAssoAdapter implements PaymentProvider {
 
 			// Handle Payment events
 			if (body.eventType === "Payment") {
-				//console.log("[HelloAsso] Payment event received");
 				const paymentData = body.data;
 
-				// Check if payment is authorized
 				if (paymentData.state === "Authorized") {
 					return {
 						isValid: true,
 						transactionId: internalId,
 						amount: paymentData.amount, // Amount is in cents
 						providerTransactionId: paymentData.id.toString(),
+					};
+				}
+
+				// Refused or Error — signal the route to mark the transaction as FAILED
+				if (paymentData.state === "Refused" || paymentData.state === "Error") {
+					return {
+						isValid: true,
+						shouldFail: true,
+						transactionId: internalId,
 					};
 				}
 			}

--- a/src/lib/payments/types.ts
+++ b/src/lib/payments/types.ts
@@ -9,6 +9,8 @@ export interface WebhookResult {
 	transactionId?: string; // The internal transaction ID
 	amount?: number; // The amount credited (without fees)
 	providerTransactionId?: string;
+	/** When true, the transaction should be marked FAILED (provider reported a declined/errored payment) */
+	shouldFail?: boolean;
 }
 
 export interface PaymentProvider {


### PR DESCRIPTION
## Résumé

- Ajoute un flag `shouldFail` à `WebhookResult` pour que l'adaptateur HelloAsso puisse signaler les paiements refusés ou en erreur
- Le handler webhook marque désormais les transactions en `FAILED` quand `shouldFail` est vrai (ces événements étaient silencieusement ignorés auparavant)
- La page de recharge annule automatiquement les transactions TOPUP en `PENDING` depuis plus de 30 minutes au chargement, couvrant le cas où l'utilisateur ferme l'onglet sans finaliser le paiement

## Plan de test

- [ ] Envoyer un webhook HelloAsso fictif avec `state: "Refused"` ou `state: "Error"` pour une transaction PENDING → le statut passe à `FAILED`
- [ ] Naviguer vers `/topup` avec une transaction TOPUP PENDING âgée de plus de 30 min en base → elle passe à `CANCELLED`
- [ ] Naviguer vers `/topup` avec une transaction TOPUP PENDING de moins de 30 min → elle reste `PENDING`
- [ ] Un webhook de paiement autorisé normal complète toujours la transaction et crédite le solde
- [ ] Les 145 tests unitaires passent (`npm test`)